### PR TITLE
Fixed type issue in FacebookGraphAPI when sdk not at webroot

### DIFF
--- a/sdk/FacebookGraphAPI.cfc
+++ b/sdk/FacebookGraphAPI.cfc
@@ -24,7 +24,7 @@ component {
 	 * @description Facebook Graph API constructor
 	 * @hint Requires an application or user accessToken
 	 */
-	public facebook.sdk.FacebookGraphAPI function init(String accessToken = "") {
+	public any function init(String accessToken = "") {
 		variables.ACCESS_TOKEN = arguments.accessToken;
 		return this;
 	}


### PR DESCRIPTION
When the facebook-cf-sdk directory was not stored in the webroot as 'facebook' the FacebookGraphAPI component would fail, because the returntype is facebook.sdk.FacebookGraphAPI.  By allowing it to return any the folder can be placed anywhere.
