### PR TITLE
Realtime subscription verification fails in Railo due to differences in how Railo deserializes the string 'null'.

### DIFF
--- a/sdk/FacebookBase.cfc
+++ b/sdk/FacebookBase.cfc
@@ -58,7 +58,7 @@ component accessors="true" {
 	private Any function callAPIService(required Http httpService) {
 		var response = arguments.httpService.send().getPrefix();
 		var result = {};
-		if (response.fileContent neq 'null' && isJSON(response.fileContent)) {
+		if (response.fileContent != 'null' && isJSON(response.fileContent)) {
 			result = deserializeJSON(response.fileContent);
 			if (isStruct(result) && (structKeyExists(result, "error") || structKeyExists(result, "error_code"))) {
 				var exception = new FacebookAPIException(result);

--- a/sdk/FacebookBase.cfc
+++ b/sdk/FacebookBase.cfc
@@ -58,7 +58,7 @@ component accessors="true" {
 	private Any function callAPIService(required Http httpService) {
 		var response = arguments.httpService.send().getPrefix();
 		var result = {};
-		if (isJSON(response.fileContent)) {
+		if (response.fileContent neq 'null' && isJSON(response.fileContent)) {
 			result = deserializeJSON(response.fileContent);
 			if (isStruct(result) && (structKeyExists(result, "error") || structKeyExists(result, "error_code"))) {
 				var exception = new FacebookAPIException(result);


### PR DESCRIPTION
If you run this code: <cfdump var="#deserializeJSON('null')#" />

Coldfusion returns the string 'null'. Whereas Railo errors out because it completely deletes the variable.
